### PR TITLE
Update to 0.10.2 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6-alpine
 
-ENV REVIEWDOG_VERSION v0.10.0
+ENV REVIEWDOG_VERSION v0.10.2
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --update --no-cache build-base git


### PR DESCRIPTION
Github runner change env variables so reviewdog was broken [Review dog issue](https://github.com/reviewdog/reviewdog/issues/708)
Need upgrade to last version of reviewdog to fix it [Reviewdog changelog](https://github.com/reviewdog/reviewdog/releases/tag/v0.10.2)