### PR TITLE
.rubocop.yml: disable EnforcedShortandSyntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,15 +31,18 @@ Layout/LineLength:
 
 Style/EachWithObject:
   Enabled: false
- 
+
 Naming/InclusiveLanguage:
   Enabled: false
-  
+
 Lint/ShadowingOuterLocalVariable:
   Enabled: false
-  
+
 Naming/MethodParameterName:
   Enabled: false
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never
 
 AllCops:
   NewCops: enable


### PR DESCRIPTION
### What does this PR do ?

This PR disables `EnforcedShortandSyntax` https://docs.rubocop.org/rubocop/cops_style.html#stylehashsyntax